### PR TITLE
metadata network list match condition in rate policies

### DIFF
--- a/graphviz.go
+++ b/graphviz.go
@@ -153,7 +153,7 @@ func buildGraph(m Metadata) string {
 		for _, rateP := range config.RatePolicies {
 			rpName := fmt.Sprintf("%q", rateP.Name)
 
-			labelData := fmt.Sprintf("{%s | id=%d}", rateP.Name, rateP.ID)
+			labelData := fmt.Sprintf("{%s | id=%d | condition=%s}", rateP.Name, rateP.ID, rateP.Condition)
 			nodeAttrs["label"] = fmt.Sprintf("%q", labelData)
 
 			if err := g.AddNode(gName, rpName, nodeAttrs); err != nil {

--- a/metadata.go
+++ b/metadata.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-
 	"github.com/tidwall/gjson"
 )
 
@@ -17,9 +16,14 @@ func ratePolicySearch(listID string, cfile []byte, cMap *ConfigurationMap) int {
 		present := nlc.Get(cond).Raw
 
 		if present != "" {
+			condition := "does not match"
+			if nlc.Get("positivematch").Bool() {
+				condition = "match"
+			}
 			rpObj := RatePolicy{
-				ID:   name.Get("id").Int(),
-				Name: name.Get("name").String(),
+				ID:        name.Get("id").Int(),
+				Name:      name.Get("name").String(),
+				Condition: condition,
 			}
 
 			cMap.RatePolicies = append(cMap.RatePolicies, rpObj)

--- a/types.go
+++ b/types.go
@@ -18,9 +18,9 @@ type ConfigurationMap struct {
 
 // RatePolicy represents network lists usage in rate policies structure
 type RatePolicy struct {
-	ID    int64  `json:"id"`
-	Name  string `json:"name"`
-	Match string `json:"matches,omitempty"`
+	ID        int64  `json:"id"`
+	Name      string `json:"name"`
+	Condition string `json:"condition,omitempty"`
 }
 
 // MatchTarget represents network lists usage in match targets structure


### PR DESCRIPTION
Added metadata information about network list match condition in rate policies.
It will allow to quickly see if condition is `match` or `does not match`.
Condition will be shown in metadata json files and in dot graphs.