### PR TITLE
Support of ALL Hostnames for graphviz generation

### DIFF
--- a/graphviz.go
+++ b/graphviz.go
@@ -107,10 +107,15 @@ func buildGraph(m Metadata) string {
 			}
 
 			hosts := []string{}
-			for _, hostname := range mTarget.Hostnames.([]interface{}) {
-				hName := fmt.Sprintf("%s", hostname)
 
-				hosts = append(hosts, hName)
+			if mTarget.Hostnames != nil {
+				for _, hostname := range mTarget.Hostnames.([]interface{}) {
+					hName := fmt.Sprintf("%s", hostname)
+
+					hosts = append(hosts, hName)
+				}
+			} else {
+				hosts = append(hosts, "All Hostnames")
 			}
 
 			labelDataHosts := fmt.Sprintf("{Match Target Hostnames | %s}", strings.Join(hosts, " | "))


### PR DESCRIPTION
Fix panic in match target configured to match all hostnames in security configuration, as in such case hostnames value is null.